### PR TITLE
Resolve inconsistent_struct_constructor style lint

### DIFF
--- a/gen/cmd/src/app.rs
+++ b/gen/cmd/src/app.rs
@@ -94,8 +94,8 @@ pub(super) fn from_args() -> Opt {
 
     Opt {
         input,
-        cxx_impl_annotations,
         header,
+        cxx_impl_annotations,
         include,
         outputs,
     }


### PR DESCRIPTION
    error: inconsistent struct constructor
       --> gen/cmd/src/app.rs:95:5
        |
    95  | /     Opt {
    96  | |         input,
    97  | |         cxx_impl_annotations,
    98  | |         header,
    99  | |         include,
    100 | |         outputs,
    101 | |     }
        | |_____^ help: try: `Opt { input, header, cxx_impl_annotations, include, outputs }`
        |
        = note: `-D clippy::inconsistent-struct-constructor` implied by `-D clippy::all`
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor